### PR TITLE
fix: use `eth_maxPriorityFeePerGas` for determing gas

### DIFF
--- a/packages/hardhat-ethers/src/internal/hardhat-ethers-provider.ts
+++ b/packages/hardhat-ethers/src/internal/hardhat-ethers-provider.ts
@@ -153,7 +153,13 @@ export class HardhatEthersProvider implements ethers.Provider {
     const latestBlock = await this.getBlock("latest");
     const baseFeePerGas = latestBlock?.baseFeePerGas;
     if (baseFeePerGas !== undefined && baseFeePerGas !== null) {
-      maxPriorityFeePerGas = 1_000_000_000n;
+      try {
+        maxPriorityFeePerGas = await this._hardhatProvider.send(
+          "eth_maxPriorityFeePerGas"
+        );
+      } catch {}
+
+      maxPriorityFeePerGas = maxPriorityFeePerGas ?? 1_000_000_000n;
       maxFeePerGas = 2n * baseFeePerGas + maxPriorityFeePerGas;
     }
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [NomicFoundation/hardhat#5157](https://togithub.com/NomicFoundation/hardhat/pull/5157).



The original branch is upstream/fix/max-priority-fee-per-gas