### PR TITLE
Use default optimizerSteps for hardhat-core::stack-traces tests

### DIFF
--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/compilation.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/compilation.ts
@@ -34,14 +34,6 @@ function getSolcInput(
 ): CompilerInput {
   const isViaIR = compilerOptions.optimizer?.viaIR ?? false;
 
-  const optimizerDetails = isViaIR
-    ? {
-        yulDetails: {
-          optimizerSteps: "u",
-        },
-      }
-    : undefined;
-
   const optimizer =
     compilerOptions.optimizer === undefined
       ? {
@@ -50,7 +42,6 @@ function getSolcInput(
       : {
           enabled: true,
           runs: compilerOptions.optimizer.runs,
-          details: optimizerDetails,
         };
 
   const settings: CompilerInput["settings"] = {

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/0_8/console-logs/error/assert/c.sol
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/0_8/console-logs/error/assert/c.sol
@@ -9,4 +9,10 @@ contract C {
     assert(b);
   }
 
+  // test2 is needed as workaround for the source mappings issue
+  // with test2 solc is forced to generate different jumpdests
+  // as a side effect proper source mappings are generated as well
+  function test2() public {
+    console.log("s");
+  }
 }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [NomicFoundation/hardhat#4052](https://togithub.com/NomicFoundation/hardhat/pull/4052).



The original branch is fork-4052-ZumZoom/fix/stack-traces-test-compilation-config