### PR TITLE
 "function call to a non-contract account" heuristic should include the address

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/error-inferrer.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/error-inferrer.ts
@@ -46,6 +46,7 @@ import {
   StackTraceEntryType,
   UnmappedSolc063RevertErrorStackTraceEntry,
 } from "./solidity-stack-trace";
+import { getNonContractAccountAddress } from "./model";
 
 const FIRST_SOLC_VERSION_CREATE_PARAMS_VALIDATION = "0.5.9";
 const FIRST_SOLC_VERSION_RECEIVE_FUNCTION = "0.6.0";
@@ -680,9 +681,11 @@ export class ErrorInferrer {
         "Expected source reference to be defined"
       );
 
+      let address = getNonContractAccountAddress(trace);
       const nonContractCalledFrame: SolidityStackTraceEntry = {
         type: StackTraceEntryType.NONCONTRACT_ACCOUNT_CALLED_ERROR,
         sourceReference,
+        address,
       };
 
       return [...stacktrace, nonContractCalledFrame];

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.ts
@@ -32,6 +32,8 @@ import {
   StackTraceEntryType,
 } from "./solidity-stack-trace";
 
+import { getNonContractAccountAddress } from "./model";
+
 const FIRST_SOLC_VERSION_WITH_MAPPED_SMALL_INTERNAL_FUNCTIONS = "0.6.9";
 
 export function stackTraceMayRequireAdjustments(
@@ -63,11 +65,13 @@ export function adjustStackTrace(
   const [revert] = stackTrace.slice(-1);
 
   if (isNonContractAccountCalledError(decodedTrace)) {
+    let address = getNonContractAccountAddress(decodedTrace);
     return [
       ...start,
       {
         type: StackTraceEntryType.NONCONTRACT_ACCOUNT_CALLED_ERROR,
         sourceReference: revert.sourceReference!,
+        address,
       },
     ];
   }

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/message-trace.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/message-trace.ts
@@ -30,6 +30,7 @@ export interface BaseEvmMessageTrace extends BaseMessageTrace {
   code: Buffer;
   value: bigint;
   returnData: Buffer;
+  calldata?: Buffer;
   error?: EvmError;
   steps: MessageTraceStep[];
   bytecode?: Bytecode;

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/model.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/model.ts
@@ -2,6 +2,8 @@ import { bufferToHex } from "@nomicfoundation/ethereumjs-util";
 
 import { AbiHelpers } from "../../util/abi-helpers";
 
+import { DecodedEvmMessageTrace } from "./message-trace";
+
 import { Opcode } from "./opcodes";
 
 /* eslint-disable @nomiclabs/hardhat-internal-rules/only-hardhat-error */
@@ -33,6 +35,13 @@ export enum ContractFunctionVisibility {
   INTERNAL,
   PUBLIC,
   EXTERNAL,
+}
+
+export function getNonContractAccountAddress(
+  decodedTrace: DecodedEvmMessageTrace
+): Buffer {
+  let callDataBuffer = decodedTrace.calldata?.toString("hex");
+  return Buffer.from("0x" + callDataBuffer?.slice(32), "utf-8");
 }
 
 export class SourceFile {

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidity-errors.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidity-errors.ts
@@ -249,7 +249,7 @@ function getMessageFromLastStackTraceEntry(
       return `Transaction reverted: function returned an unexpected amount of data`;
 
     case StackTraceEntryType.NONCONTRACT_ACCOUNT_CALLED_ERROR:
-      return `Transaction reverted: function call to a non-contract account`;
+      return `Transaction reverted: function call to a non-contract account ${stackTraceEntry.address}`;
 
     case StackTraceEntryType.CALL_FAILED_ERROR:
       return `Transaction reverted: function call failed to execute`;

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidity-stack-trace.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidity-stack-trace.ts
@@ -2,6 +2,8 @@ import { ReturnData } from "../provider/return-data";
 
 import { ContractFunctionType } from "./model";
 
+
+
 export enum StackTraceEntryType {
   CALLSTACK_ENTRY,
   UNRECOGNIZED_CREATE_CALLSTACK_ENTRY,
@@ -137,6 +139,7 @@ export interface ReturndataSizeErrorStackTraceEntry {
 export interface NonContractAccountCalledErrorStackTraceEntry {
   type: StackTraceEntryType.NONCONTRACT_ACCOUNT_CALLED_ERROR;
   sourceReference: SourceReference;
+  address:Buffer;
 }
 
 export interface CallFailedErrorStackTraceEntry {


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [NomicFoundation/hardhat#3870](https://togithub.com/NomicFoundation/hardhat/pull/3870).



The original branch is fork-3870-ZainGulbaz/function-call-to-non-contract-account-should-contain-address