### PR TITLE
Fix gas-provider error caused by empty blocks

### DIFF
--- a/packages/hardhat-core/src/internal/core/providers/gas-providers.ts
+++ b/packages/hardhat-core/src/internal/core/providers/gas-providers.ts
@@ -4,6 +4,7 @@ import {
   rpcQuantityToNumber,
   rpcQuantityToBigInt,
 } from "../jsonrpc/types/base-types";
+import * as BigIntUtils from "../../util/bigint";
 
 import { ProviderWrapper } from "./wrapper";
 
@@ -268,7 +269,10 @@ export class AutomaticGasPriceProvider extends ProviderWrapper {
             (AutomaticGasPriceProvider.EIP1559_BASE_FEE_MAX_FULL_BLOCKS_PREFERENCE -
               1n),
 
-        maxPriorityFeePerGas: rpcQuantityToBigInt(response.reward[0][0]),
+        maxPriorityFeePerGas: BigIntUtils.max(
+          rpcQuantityToBigInt(response.reward[0][0]),
+          1n
+        ),
       };
     } catch {
       this._nodeHasFeeHistory = false;


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [NomicFoundation/hardhat#3851](https://togithub.com/NomicFoundation/hardhat/pull/3851).



The original branch is fork-3851-LEAFERx/fix_gas_provider_when_empty_block